### PR TITLE
Improve supports for old Quicktime atom

### DIFF
--- a/box.go
+++ b/box.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"errors"
+	"io"
 )
 
 type ICustomFieldObject interface {
@@ -16,6 +17,8 @@ type ICustomFieldObject interface {
 
 	// StringifyField returns field value as string
 	StringifyField(string, string, int) (string, bool)
+
+	BeforeUnmarshal(r io.ReadSeeker) (n uint64, override bool, err error)
 }
 
 type BaseCustomFieldObject struct {
@@ -39,6 +42,10 @@ func (box *BaseCustomFieldObject) IsOptFieldEnabled(string) bool {
 // StringifyField returns field value as string
 func (box *BaseCustomFieldObject) StringifyField(string, string, int) (string, bool) {
 	return "", false
+}
+
+func (*BaseCustomFieldObject) BeforeUnmarshal(r io.ReadSeeker) (uint64, bool, error) {
+	return 0, false, nil
 }
 
 // IImmutableBox is common interface of box

--- a/box.go
+++ b/box.go
@@ -18,6 +18,8 @@ type ICustomFieldObject interface {
 	// StringifyField returns field value as string
 	StringifyField(string, string, int) (string, bool)
 
+	IsPString(name string, bytes []byte, remainingSize uint64) bool
+
 	BeforeUnmarshal(r io.ReadSeeker) (n uint64, override bool, err error)
 }
 
@@ -42,6 +44,10 @@ func (box *BaseCustomFieldObject) IsOptFieldEnabled(string) bool {
 // StringifyField returns field value as string
 func (box *BaseCustomFieldObject) StringifyField(string, string, int) (string, bool) {
 	return "", false
+}
+
+func (*BaseCustomFieldObject) IsPString(name string, bytes []byte, remainingSize uint64) bool {
+	return true
 }
 
 func (*BaseCustomFieldObject) BeforeUnmarshal(r io.ReadSeeker) (uint64, bool, error) {

--- a/hdlr_test.go
+++ b/hdlr_test.go
@@ -9,14 +9,47 @@ import (
 
 func TestHdlrUnmarshalHandlerName(t *testing.T) {
 	testCases := []struct {
-		name  string
-		bytes []byte
-		want  string
+		name          string
+		componentType []byte
+		bytes         []byte
+		want          string
 	}{
-		{name: "NormalString", bytes: []byte("abema"), want: "abema"},
-		{name: "EmptyString", bytes: nil, want: ""},
-		{name: "AppleQuickTimePascalString", bytes: []byte{5, 'a', 'b', 'e', 'm', 'a'}, want: "abema"},
-		{name: "AppleQuickTimePascalStringWithEmpty", bytes: []byte{0x00, 0x00}, want: ""},
+		{
+			name:          "NormalString",
+			componentType: []byte{0x00, 0x00, 0x00, 0x00},
+			bytes:         []byte("abema"),
+			want:          "abema",
+		},
+		{
+			name:          "EmptyString",
+			componentType: []byte{0x00, 0x00, 0x00, 0x00},
+			bytes:         nil,
+			want:          "",
+		},
+		{
+			name:          "NormalLongString",
+			componentType: []byte{0x00, 0x00, 0x00, 0x00},
+			bytes:         []byte(" a 1st byte equals to this length"),
+			want:          " a 1st byte equals to this length",
+		},
+		{
+			name:          "AppleQuickTimePascalString",
+			componentType: []byte("mhlr"),
+			bytes:         []byte{5, 'a', 'b', 'e', 'm', 'a'},
+			want:          "abema",
+		},
+		{
+			name:          "AppleQuickTimePascalStringWithEmpty",
+			componentType: []byte("mhlr"),
+			bytes:         []byte{0x00},
+			want:          "",
+		},
+		{
+			name:          "AppleQuickTimePascalStringLong",
+			componentType: []byte("mhlr"),
+			bytes:         []byte(" a 1st byte equals to this length"),
+			want:          "a 1st byte equals to this length",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -24,12 +57,14 @@ func TestHdlrUnmarshalHandlerName(t *testing.T) {
 			bin := []byte{
 				0,                // version
 				0x00, 0x00, 0x00, // flags
-				0x00, 0x00, 0x00, 0x00, // predefined
+			}
+			bin = append(bin, tc.componentType...)
+			bin = append(bin,
 				'v', 'i', 'd', 'e', // handler type
 				0x00, 0x00, 0x00, 0x00, // reserved
 				0x00, 0x00, 0x00, 0x00, // reserved
 				0x00, 0x00, 0x00, 0x00, // reserved
-			}
+			)
 			bin = append(bin, tc.bytes...)
 
 			// unmarshal

--- a/meta.go
+++ b/meta.go
@@ -1,5 +1,7 @@
 package mp4
 
+import "io"
+
 func BoxTypeMeta() BoxType { return StrToBoxType("meta") }
 
 func init() {
@@ -14,4 +16,21 @@ type Meta struct {
 // GetType returns the BoxType
 func (*Meta) GetType() BoxType {
 	return BoxTypeMeta()
+}
+
+func (meta *Meta) BeforeUnmarshal(r io.ReadSeeker) (n uint64, override bool, err error) {
+	// for Apple Quick Time
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return 0, false, err
+	}
+	if _, err := r.Seek(-int64(len(buf)), io.SeekCurrent); err != nil {
+		return 0, false, err
+	}
+	if buf[0]|buf[1]|buf[2]|buf[3] != 0x00 {
+		meta.Version = 0
+		meta.Flags = [3]byte{0, 0, 0}
+		return 0, true, nil
+	}
+	return 0, false, nil
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -52,4 +52,6 @@ func TestMetaMarshalAppleQuickTime(t *testing.T) {
 	assert.Equal(t, uint64(0), n)
 	s, _ := r.Seek(0, io.SeekCurrent)
 	assert.Equal(t, int64(0), s)
+	assert.Equal(t, uint8(0), dst.GetVersion())
+	assert.Equal(t, uint32(0), dst.GetFlags())
 }


### PR DESCRIPTION
Issue: https://github.com/abema/go-mp4/issues/7

- PString support
    - Try to read the data as PString (Length-Prefixed String) for fields having `string=c_p`.
    - Check whether the `component_type` of `hdlr` is non-zero.
- `BeforeUnmarshal` function
    - Hook a invocation of Unmarshal and override the processing if the box is old QuickTime style.
    - Unset `version` and `flags` of `meta`.