### PR TITLE
Fix hdlr bug

### DIFF
--- a/box_types.go
+++ b/box_types.go
@@ -400,6 +400,7 @@ type Hdlr struct {
 	HandlerType [4]byte   `mp4:"size=8,string"`
 	Reserved    [3]uint32 `mp4:"size=32,const=0"`
 	Name        string    `mp4:"string=c_p"`
+	Padding     []byte    `mp4:"size=8,const=0"`
 }
 
 // GetType returns the BoxType

--- a/box_types_test.go
+++ b/box_types_test.go
@@ -327,6 +327,7 @@ func TestHdlrUnmarshalHandlerName(t *testing.T) {
 		componentType []byte
 		bytes         []byte
 		want          string
+		padding       int
 	}{
 		{
 			name:          "NormalString",
@@ -355,8 +356,9 @@ func TestHdlrUnmarshalHandlerName(t *testing.T) {
 		{
 			name:          "AppleQuickTimePascalStringWithEmpty",
 			componentType: []byte("mhlr"),
-			bytes:         []byte{0x00},
+			bytes:         []byte{0x00, 0x00},
 			want:          "",
+			padding:       1,
 		},
 		{
 			name:          "AppleQuickTimePascalStringLong",
@@ -389,6 +391,7 @@ func TestHdlrUnmarshalHandlerName(t *testing.T) {
 			assert.Equal(t, uint64(len(bin)), n)
 			assert.Equal(t, [4]byte{'v', 'i', 'd', 'e'}, dst.HandlerType)
 			assert.Equal(t, tc.want, dst.Name)
+			assert.Len(t, dst.Padding, tc.padding)
 		})
 	}
 }

--- a/extract_test.go
+++ b/extract_test.go
@@ -44,6 +44,7 @@ func TestExtractBoxWithPayload(t *testing.T) {
 					Payload: &Hdlr{
 						HandlerType: [4]byte{'v', 'i', 'd', 'e'},
 						Name:        "VideoHandle",
+						Padding:     []byte{},
 					},
 				},
 				{
@@ -51,6 +52,7 @@ func TestExtractBoxWithPayload(t *testing.T) {
 					Payload: &Hdlr{
 						HandlerType: [4]byte{'s', 'o', 'u', 'n'},
 						Name:        "SoundHandle",
+						Padding:     []byte{},
 					},
 				},
 			},


### PR DESCRIPTION
Fix the bug introduced by https://github.com/abema/go-mp4/pull/6 .

Apple style hdlr.name represents empty string by `[]byte{0x00, 0x00}` perhaps.
But I have confirm that from actual MP4 files only, and can found no official technical documentations.

Related to https://github.com/abema/go-mp4/issues/7 , https://github.com/abema/go-mp4/pull/4