### PR TITLE
Fix stringify function for fixed point number

### DIFF
--- a/box_types.go
+++ b/box_types.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/abema/go-mp4/bitio"
 	"github.com/abema/go-mp4/util"
@@ -847,7 +846,7 @@ func (*Mvhd) GetType() BoxType {
 func (mvhd *Mvhd) StringifyField(name string, indent string, depth int, bss BoxStructureStatus) (string, bool) {
 	switch name {
 	case "Rate":
-		return strconv.FormatFloat(mvhd.GetRate(), 'f', -1, 32), true
+		return util.FormatSignedFixedFloat1616(mvhd.Rate), true
 	default:
 		return "", false
 	}
@@ -1392,7 +1391,7 @@ func (*Smhd) GetType() BoxType {
 func (smhd *Smhd) StringifyField(name string, indent string, depth int, bss BoxStructureStatus) (string, bool) {
 	switch name {
 	case "Balance":
-		return strconv.FormatFloat(float64(smhd.GetBalance()), 'f', -1, 32), true
+		return util.FormatSignedFixedFloat88(smhd.Balance), true
 	default:
 		return "", false
 	}
@@ -1797,9 +1796,9 @@ func (*Tkhd) GetType() BoxType {
 func (tkhd *Tkhd) StringifyField(name string, indent string, depth int, bss BoxStructureStatus) (string, bool) {
 	switch name {
 	case "Width":
-		return strconv.FormatFloat(tkhd.GetWidth(), 'f', -1, 32), true
+		return util.FormatUnsignedFixedFloat1616(tkhd.Width), true
 	case "Height":
-		return strconv.FormatFloat(tkhd.GetHeight(), 'f', -1, 32), true
+		return util.FormatUnsignedFixedFloat1616(tkhd.Height), true
 	default:
 		return "", false
 	}

--- a/box_types_test.go
+++ b/box_types_test.go
@@ -748,7 +748,7 @@ func TestBoxTypes(t *testing.T) {
 				`ModificationTimeV0=591751049 ` +
 				`Timescale=1164413355 ` +
 				`DurationV0=1737075661 ` +
-				`Rate=-291.27112 ` +
+				`Rate=-291.27110 ` +
 				`Volume=291 ` +
 				`Matrix=[0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0] ` +
 				`PreDefined=[0, 0, 0, 0, 0, 0] ` +
@@ -795,7 +795,7 @@ func TestBoxTypes(t *testing.T) {
 				`ModificationTimeV1=2541551405711093505 ` +
 				`Timescale=2309737967 ` +
 				`DurationV1=5001117282205630755 ` +
-				`Rate=-291.27112 ` +
+				`Rate=-291.27110 ` +
 				`Volume=291 ` +
 				`Matrix=[0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0] ` +
 				`PreDefined=[0, 0, 0, 0, 0, 0] ` +
@@ -1823,7 +1823,7 @@ func TestBoxTypes(t *testing.T) {
 				0x01, 0x23, // balance
 				0x00, 0x00, // reserved
 			},
-			str: `Version=0 Flags=0x000000 Balance=1.1367188`,
+			str: `Version=0 Flags=0x000000 Balance=1.137`,
 		},
 		{
 			name: "stbl",

--- a/util/string.go
+++ b/util/string.go
@@ -1,0 +1,27 @@
+package util
+
+import "strconv"
+
+func FormatSignedFixedFloat1616(val int32) string {
+	if val&0xffff == 0 {
+		return strconv.Itoa(int(val >> 16))
+	} else {
+		return strconv.FormatFloat(float64(val)/(1<<16), 'f', 5, 64)
+	}
+}
+
+func FormatUnsignedFixedFloat1616(val uint32) string {
+	if val&0xffff == 0 {
+		return strconv.Itoa(int(val >> 16))
+	} else {
+		return strconv.FormatFloat(float64(val)/(1<<16), 'f', 5, 64)
+	}
+}
+
+func FormatSignedFixedFloat88(val int16) string {
+	if val&0xff == 0 {
+		return strconv.Itoa(int(val >> 8))
+	} else {
+		return strconv.FormatFloat(float64(val)/(1<<8), 'f', 3, 32)
+	}
+}

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatSignedFixedFloat1616(t *testing.T) {
+	assert.Equal(t, "1", FormatSignedFixedFloat1616(0x00010000))
+	assert.Equal(t, "1234", FormatSignedFixedFloat1616(0x04d20000))
+	assert.Equal(t, "-1234", FormatSignedFixedFloat1616(-0x04d20000))
+	assert.Equal(t, "1.50000", FormatSignedFixedFloat1616(0x00018000))
+	assert.Equal(t, "1234.56789", FormatSignedFixedFloat1616(0x04d29161))
+	assert.Equal(t, "-1234.56789", FormatSignedFixedFloat1616(-0x04d29161))
+}
+
+func TestFormatUnsignedFixedFloat1616(t *testing.T) {
+	assert.Equal(t, "1", FormatUnsignedFixedFloat1616(0x00010000))
+	assert.Equal(t, "1234", FormatUnsignedFixedFloat1616(0x04d20000))
+	assert.Equal(t, "1.50000", FormatUnsignedFixedFloat1616(0x00018000))
+	assert.Equal(t, "1234.56789", FormatUnsignedFixedFloat1616(0x04d29161))
+	assert.Equal(t, "65535.99998", FormatUnsignedFixedFloat1616(0xffffffff))
+}
+
+func TestFormatSignedFixedFloat88(t *testing.T) {
+	assert.Equal(t, "1", FormatSignedFixedFloat88(0x0100))
+	assert.Equal(t, "123", FormatSignedFixedFloat88(0x7b00))
+	assert.Equal(t, "-123", FormatSignedFixedFloat88(-0x7b00))
+	assert.Equal(t, "1.500", FormatSignedFixedFloat88(0x0180))
+	assert.Equal(t, "123.457", FormatSignedFixedFloat88(0x7b75))
+	assert.Equal(t, "-123.457", FormatSignedFixedFloat88(-0x7b75))
+}


### PR DESCRIPTION
https://github.com/abema/go-mp4/issues/54

Fix the value of bitSize argument from 32 to 64.