### PR TITLE
escape unprintable runes by box_types.go

### DIFF
--- a/box_types.go
+++ b/box_types.go
@@ -686,7 +686,7 @@ func (data *Data) StringifyField(name string, indent string, depth int, ctx Cont
 	case "Data":
 		switch data.DataType {
 		case DataTypeStringUTF8:
-			return fmt.Sprintf("\"%s\"", string(data.Data)), true
+			return fmt.Sprintf("\"%s\"", util.EscapeUnprintables(string(data.Data))), true
 		}
 	}
 	return "", false
@@ -700,7 +700,7 @@ type StringData struct {
 // StringifyField returns field value as string
 func (sd *StringData) StringifyField(name string, indent string, depth int, ctx Context) (string, bool) {
 	if name == "Data" {
-		return fmt.Sprintf("\"%s\"", string(sd.Data)), true
+		return fmt.Sprintf("\"%s\"", util.EscapeUnprintables(string(sd.Data))), true
 	}
 	return "", false
 }
@@ -1120,7 +1120,7 @@ func (vse *VisualSampleEntry) StringifyField(name string, indent string, depth i
 	switch name {
 	case "Compressorname":
 		if vse.Compressorname[0] <= 31 {
-			return `"` + string(vse.Compressorname[1:vse.Compressorname[0]+1]) + `"`, true
+			return `"` + util.EscapeUnprintables(string(vse.Compressorname[1:vse.Compressorname[0]+1])) + `"`, true
 		}
 		return "", false
 	default:

--- a/box_types_test.go
+++ b/box_types_test.go
@@ -538,6 +538,18 @@ func TestBoxTypes(t *testing.T) {
 			ctx: Context{UnderIlstMeta: true},
 		},
 		{
+			name: "ilst data (utf8 escaped)",
+			src:  &Data{DataType: 1, DataLang: 0x12345678, Data: []byte{0x00, 'f', 'o', 'o'}},
+			dst:  &Data{},
+			bin: []byte{
+				0x00, 0x00, 0x00, 0x01, // data type
+				0x12, 0x34, 0x56, 0x78, // data lang
+				0x00, 0x66, 0x6f, 0x6f, // data
+			},
+			str: `DataType=UTF8 DataLang=305419896 Data=".foo"`,
+			ctx: Context{UnderIlstMeta: true},
+		},
+		{
 			name: "ilst data (utf16)",
 			src:  &Data{DataType: 2, DataLang: 0x12345678, Data: []byte("foo")},
 			dst:  &Data{},
@@ -613,15 +625,15 @@ func TestBoxTypes(t *testing.T) {
 			name: "ilst data (string)",
 			src: &StringData{
 				AnyTypeBox: AnyTypeBox{Type: StrToBoxType("mean")},
-				Data:       []byte("foo"),
+				Data:       []byte{0x00, 'f', 'o', 'o'},
 			},
 			dst: &StringData{
 				AnyTypeBox: AnyTypeBox{Type: StrToBoxType("mean")},
 			},
 			bin: []byte{
-				0x66, 0x6f, 0x6f, // data
+				0x00, 0x66, 0x6f, 0x6f, // data
 			},
-			str: `Data="foo"`,
+			str: `Data=".foo"`,
 			ctx: Context{UnderIlstFreeMeta: true},
 		},
 		{
@@ -998,7 +1010,7 @@ func TestBoxTypes(t *testing.T) {
 				Vertresolution:  0x01000005,
 				Reserved2:       0x01000006,
 				FrameCount:      0x0104,
-				Compressorname:  [32]byte{5, 'a', 'b', 'e', 'm', 'a'},
+				Compressorname:  [32]byte{8, 'a', 'b', 'e', 'm', 'a', 0x00, 't', 'v'},
 				Depth:           0x0105,
 				PreDefined3:     1001,
 			},
@@ -1017,8 +1029,8 @@ func TestBoxTypes(t *testing.T) {
 				0x01, 0x00, 0x00, 0x05, // Vertresolution
 				0x01, 0x00, 0x00, 0x06, // Reserved2
 				0x01, 0x04, // FrameCount
-				5, 'a', 'b', 'e', 'm', 'a', 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				8, 'a', 'b', 'e', 'm', 'a', 0x00, 't',
+				'v', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Compressorname
 				0x01, 0x05, // Depth
@@ -1032,7 +1044,7 @@ func TestBoxTypes(t *testing.T) {
 				`Horizresolution=16777220 ` +
 				`Vertresolution=16777221 ` +
 				`FrameCount=260 ` +
-				`Compressorname="abema" ` +
+				`Compressorname="abema.tv" ` +
 				`Depth=261 ` +
 				`PreDefined3=1001`,
 		},


### PR DESCRIPTION
escape unprintable runes by box_types.go
related to https://github.com/abema/go-mp4/pull/65