### PR TITLE
Fix to skip BoxTypeAny() in extract.go

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -64,6 +64,9 @@ func ExtractBoxes(r io.ReadSeeker, parent *BoxInfo, paths []BoxPath) ([]*BoxInfo
 		if parent != nil {
 			path = path[1:]
 		}
+		if handle.BoxInfo.Type == BoxTypeAny() {
+			return nil, nil
+		}
 		fm, m := matchPath(paths, path)
 		if m {
 			boxes = append(boxes, &handle.BoxInfo)


### PR DESCRIPTION
Reject the box type which equals to BoxTypeAny() before matchPath.