### PR TITLE
Improve compatibility of esds boxes

### DIFF
--- a/box_types_test.go
+++ b/box_types_test.go
@@ -381,7 +381,7 @@ func TestBoxTypes(t *testing.T) {
 				Descriptors: []Descriptor{
 					{
 						Tag:  ESDescrTag,
-						Size: 0x12345678,
+						Size: 0x1234567,
 						ESDescriptor: &ESDescriptor{
 							ESID:                 0x1234,
 							StreamDependenceFlag: true,
@@ -394,7 +394,7 @@ func TestBoxTypes(t *testing.T) {
 					},
 					{
 						Tag:  ESDescrTag,
-						Size: 0x12345678,
+						Size: 0x1234567,
 						ESDescriptor: &ESDescriptor{
 							ESID:                 0x1234,
 							StreamDependenceFlag: false,
@@ -407,7 +407,7 @@ func TestBoxTypes(t *testing.T) {
 					},
 					{
 						Tag:  DecoderConfigDescrTag,
-						Size: 0x12345678,
+						Size: 0x1234567,
 						DecoderConfigDescriptor: &DecoderConfigDescriptor{
 							ObjectTypeIndication: 0x12,
 							StreamType:           0x15,
@@ -435,40 +435,40 @@ func TestBoxTypes(t *testing.T) {
 				0,                // version
 				0x00, 0x00, 0x00, // flags
 				//
-				0x03,                         // tag
-				0x81, 0x91, 0xD1, 0xAC, 0x78, // size (varint)
+				0x03,                   // tag
+				0x89, 0x8d, 0x8a, 0x67, // size (varint)
 				0x12, 0x34, // esid
 				0xa3,       // flags & streamPriority
 				0x23, 0x45, // dependsOnESID
 				0x34, 0x56, // ocresid
 				//
-				0x03,                         // tag
-				0x81, 0x91, 0xD1, 0xAC, 0x78, // size (varint)
+				0x03,                   // tag
+				0x89, 0x8d, 0x8a, 0x67, // size (varint)
 				0x12, 0x34, // esid
 				0x43,                                                  // flags & streamPriority
 				11,                                                    // urlLength
 				'h', 't', 't', 'p', ':', '/', '/', 'h', 'o', 'g', 'e', // urlString
 				//
-				0x04,                         // tag
-				0x81, 0x91, 0xD1, 0xAC, 0x78, // size (varint)
+				0x04,                   // tag
+				0x89, 0x8d, 0x8a, 0x67, // size (varint)
 				0x12,             // objectTypeIndication
 				0x56,             // streamType & upStream & reserved
 				0x12, 0x34, 0x56, // bufferSizeDB
 				0x12, 0x34, 0x56, 0x78, // maxBitrate
 				0x23, 0x45, 0x67, 0x89, // avgBitrate
 				//
-				0x05,             // tag
-				0x03,             // size (varint)
+				0x05,                   // tag
+				0x80, 0x80, 0x80, 0x03, // size (varint)
 				0x11, 0x22, 0x33, // data
 				//
-				0x06,                         // tag
-				0x05,                         // size (varint)
+				0x06,                   // tag
+				0x80, 0x80, 0x80, 0x05, // size (varint)
 				0x11, 0x22, 0x33, 0x44, 0x55, // data
 			},
 			str: `Version=0 Flags=0x000000 Descriptors=[` +
-				`{Tag=ESDescr Size=305419896 ESID=4660 StreamDependenceFlag=true UrlFlag=false OcrStreamFlag=true StreamPriority=3 DependsOnESID=9029 OCRESID=13398}, ` +
-				`{Tag=ESDescr Size=305419896 ESID=4660 StreamDependenceFlag=false UrlFlag=true OcrStreamFlag=false StreamPriority=3 URLLength=0xb URLString="http://hoge"}, ` +
-				`{Tag=DecoderConfigDescr Size=305419896 ObjectTypeIndication=0x12 StreamType=21 UpStream=true Reserved=false BufferSizeDB=1193046 MaxBitrate=305419896 AvgBitrate=591751049}, ` +
+				`{Tag=ESDescr Size=19088743 ESID=4660 StreamDependenceFlag=true UrlFlag=false OcrStreamFlag=true StreamPriority=3 DependsOnESID=9029 OCRESID=13398}, ` +
+				`{Tag=ESDescr Size=19088743 ESID=4660 StreamDependenceFlag=false UrlFlag=true OcrStreamFlag=false StreamPriority=3 URLLength=0xb URLString="http://hoge"}, ` +
+				`{Tag=DecoderConfigDescr Size=19088743 ObjectTypeIndication=0x12 StreamType=21 UpStream=true Reserved=false BufferSizeDB=1193046 MaxBitrate=305419896 AvgBitrate=591751049}, ` +
 				"{Tag=DecSpecificInfo Size=3 Data=[0x11, 0x22, 0x33]}, " +
 				"{Tag=SLConfigDescr Size=5 Data=[0x11, 0x22, 0x33, 0x44, 0x55]}]",
 		},

--- a/marshaller.go
+++ b/marshaller.go
@@ -230,25 +230,18 @@ func (m *marshaller) marshalString(v reflect.Value) error {
 }
 
 func (m *marshaller) writeUvarint(u uint64) error {
-	if u == 0 {
-		if err := m.writer.WriteBits([]byte{0}, 8); err != nil {
+	for i := 21; i > 0; i -= 7 {
+		if err := m.writer.WriteBits([]byte{(byte(u >> uint(i))) | 0x80}, 8); err != nil {
 			return err
 		}
 		m.wbits += 8
-		return nil
 	}
-	for i := 63; i >= 0; i -= 7 {
-		if u>>uint(i) != 0 {
-			data := byte(u>>uint(i)) & 0x7f
-			if i != 0 {
-				data |= 0x80
-			}
-			if err := m.writer.WriteBits([]byte{data}, 8); err != nil {
-				return err
-			}
-			m.wbits += 8
-		}
+
+	if err := m.writer.WriteBits([]byte{byte(u) & 0x7f}, 8); err != nil {
+		return err
 	}
+	m.wbits += 8
+
 	return nil
 }
 


### PR DESCRIPTION
@sunfish-shogi

Firefox and Chrome aren't currently able to read varints with a size different than 4. ISO 14496-1 isn't clear on the matter, although it limits the maximum varint size to 4.

This patch forces varints to have a size of 4, allowing a broader compatibility of esds boxes. Sizes greater than 4 are not supported anymore (but this is dictated by the specification).

References:
https://stackoverflow.com/questions/30998150/build-an-esds-box-for-an-mp4-that-firefox-can-play
https://github.com/FFmpeg/FFmpeg/blob/0922c6b01bd50f0ce6e659f765c244f6a8f29eb3/libavformat/movenc.c#L646
ISO 14496-1

PS: thank you very much for this library, it allows [rtsp-simple-server](https://github.com/aler9/rtsp-simple-server) to produce and read Low-Latency HLS fragments.