### PR TITLE
add hvc1 box

### DIFF
--- a/box_types.go
+++ b/box_types.go
@@ -1548,6 +1548,7 @@ func (*Saiz) GetType() BoxType {
 func BoxTypeAvc1() BoxType { return StrToBoxType("avc1") }
 func BoxTypeEncv() BoxType { return StrToBoxType("encv") }
 func BoxTypeHev1() BoxType { return StrToBoxType("hev1") }
+func BoxTypeHvc1() BoxType { return StrToBoxType("hvc1") }
 func BoxTypeMp4a() BoxType { return StrToBoxType("mp4a") }
 func BoxTypeEnca() BoxType { return StrToBoxType("enca") }
 func BoxTypeAvcC() BoxType { return StrToBoxType("avcC") }
@@ -1557,6 +1558,7 @@ func init() {
 	AddAnyTypeBoxDef(&VisualSampleEntry{}, BoxTypeAvc1())
 	AddAnyTypeBoxDef(&VisualSampleEntry{}, BoxTypeEncv())
 	AddAnyTypeBoxDef(&VisualSampleEntry{}, BoxTypeHev1())
+	AddAnyTypeBoxDef(&VisualSampleEntry{}, BoxTypeHvc1())
 	AddAnyTypeBoxDef(&AudioSampleEntry{}, BoxTypeMp4a())
 	AddAnyTypeBoxDef(&AudioSampleEntry{}, BoxTypeEnca())
 	AddAnyTypeBoxDef(&AVCDecoderConfiguration{}, BoxTypeAvcC())


### PR DESCRIPTION
Hello @sunfish-shogi, i thought the H265 implementation was complete but there's a box missing.

According to ISO/IEC FDIS 14496-15:2019(E), section  8.3.2:

> Parameter sets: A parameter set to be used in a picture must be sent prior to the sample containing that picture or in the sample for that picture. For a video stream that a particular sample entry applies to, the video parameter set, sequence parameter sets, and picture parameter sets, shall be stored only in the sample entry when the sample entry name is ‘hvc1’, and may be stored in the sample entry and the samples when the sample entry name is ‘hev1’.

H265 has two sample entry names, the first one is 'hev1' (added in the previous PR) and the second one is 'hvc1'. 'hev1' is used when VPS/SPS/PPS are both in the track header and inside the stream, while 'hvc1' is used when VPS/SPS/PPS are in the track header only.