### PR TITLE
Display SampleRate with human-readable format

### DIFF
--- a/box_types.go
+++ b/box_types.go
@@ -1608,7 +1608,7 @@ type AudioSampleEntry struct {
 	SampleSize    uint16    `mp4:"4,size=16,opt=dynamic"`
 	PreDefined    uint16    `mp4:"5,size=16,opt=dynamic"`
 	Reserved2     uint16    `mp4:"6,size=16,opt=dynamic,const=0"`
-	SampleRate    uint32    `mp4:"7,size=32,opt=dynamic"`
+	SampleRate    uint32    `mp4:"7,size=32,opt=dynamic"` // fixed-point 16.16
 	QuickTimeData []byte    `mp4:"8,size=8,opt=dynamic,len=dynamic"`
 }
 
@@ -1633,6 +1633,16 @@ func (ase *AudioSampleEntry) GetFieldLength(name string, ctx Context) uint {
 		}
 	}
 	return 0
+}
+
+// StringifyField returns field value as string
+func (ase *AudioSampleEntry) StringifyField(name string, indent string, depth int, ctx Context) (string, bool) {
+	switch name {
+	case "SampleRate":
+		return util.FormatUnsignedFixedFloat1616(ase.SampleRate), true
+	default:
+		return "", false
+	}
 }
 
 const (

--- a/box_types.go
+++ b/box_types.go
@@ -1645,6 +1645,14 @@ func (ase *AudioSampleEntry) StringifyField(name string, indent string, depth in
 	}
 }
 
+func (ase *AudioSampleEntry) GetSampleRate() float64 {
+	return float64(ase.SampleRate) / (1 << 16)
+}
+
+func (ase *AudioSampleEntry) GetSampleRateInt() uint16 {
+	return uint16(ase.SampleRate >> 16)
+}
+
 const (
 	AVCBaselineProfile uint8 = 66  // 0x42
 	AVCMainProfile     uint8 = 77  // 0x4d

--- a/box_types_test.go
+++ b/box_types_test.go
@@ -3362,6 +3362,10 @@ func TestFixedPoint(t *testing.T) {
 	assert.Equal(t, uint16(32), tkhd.GetWidthInt())
 	assert.Equal(t, float64(1516.171875), tkhd.GetHeight())
 	assert.Equal(t, uint16(1516), tkhd.GetHeightInt())
+
+	ase := AudioSampleEntry{SampleRate: 0x205800}
+	assert.Equal(t, float64(32.34375), ase.GetSampleRate())
+	assert.Equal(t, uint16(32), ase.GetSampleRateInt())
 }
 
 func TestGetters(t *testing.T) {

--- a/box_types_test.go
+++ b/box_types_test.go
@@ -1389,7 +1389,7 @@ func TestBoxTypes(t *testing.T) {
 				`ChannelCount=9029 ` +
 				`SampleSize=17767 ` +
 				`PreDefined=26505 ` +
-				`SampleRate=19088743`,
+				`SampleRate=291.27110`,
 		},
 		{
 			name: "AudioSampleEntry",
@@ -1421,7 +1421,7 @@ func TestBoxTypes(t *testing.T) {
 				`ChannelCount=9029 ` +
 				`SampleSize=17767 ` +
 				`PreDefined=26505 ` +
-				`SampleRate=19088743`,
+				`SampleRate=291.27110`,
 		},
 		{
 			name: "AudioSampleEntry (QuickTime v0)",
@@ -1453,7 +1453,7 @@ func TestBoxTypes(t *testing.T) {
 				`ChannelCount=9029 ` +
 				`SampleSize=17767 ` +
 				`PreDefined=26505 ` +
-				`SampleRate=19088743`,
+				`SampleRate=291.27110`,
 			ctx: Context{IsQuickTimeCompatible: true},
 		},
 		{
@@ -1488,7 +1488,7 @@ func TestBoxTypes(t *testing.T) {
 				`ChannelCount=9029 ` +
 				`SampleSize=17767 ` +
 				`PreDefined=26505 ` +
-				`SampleRate=19088743 ` +
+				`SampleRate=291.27110 ` +
 				`QuickTimeData=[0x0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]`,
 			ctx: Context{IsQuickTimeCompatible: true},
 		},
@@ -1530,7 +1530,7 @@ func TestBoxTypes(t *testing.T) {
 				`ChannelCount=9029 ` +
 				`SampleSize=17767 ` +
 				`PreDefined=26505 ` +
-				`SampleRate=19088743 ` +
+				`SampleRate=291.27110 ` +
 				`QuickTimeData=[` +
 				`0x0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, ` +
 				`0x0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, ` +

--- a/mp4tool/dump/dump_test.go
+++ b/mp4tool/dump/dump_test.go
@@ -101,7 +101,7 @@ var sampleMP4Output = "" +
 	`            [url ] Size=12 Version=0 Flags=0x000001` + "\n" +
 	`        [stbl] Size=564` + "\n" +
 	`          [stsd] Size=106 Version=0 Flags=0x000000 EntryCount=1` + "\n" +
-	`            [mp4a] Size=90 DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=2890137600` + "\n" +
+	`            [mp4a] Size=90 DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=44100` + "\n" +
 	`              [esds] Size=54 ... (use "-full esds" to show all)` + "\n" +
 	`          [stts] Size=48 ... (use "-full stts" to show all)` + "\n" +
 	`          [stsc] Size=100 ... (use "-full stsc" to show all)` + "\n" +
@@ -160,7 +160,7 @@ var sampleMP4OutputFullMvhdLoci = "" +
 	`            [url ] Size=12 Version=0 Flags=0x000001` + "\n" +
 	`        [stbl] Size=564` + "\n" +
 	`          [stsd] Size=106 Version=0 Flags=0x000000 EntryCount=1` + "\n" +
-	`            [mp4a] Size=90 DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=2890137600` + "\n" +
+	`            [mp4a] Size=90 DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=44100` + "\n" +
 	`              [esds] Size=54 ... (use "-full esds" to show all)` + "\n" +
 	`          [stts] Size=48 ... (use "-full stts" to show all)` + "\n" +
 	`          [stsc] Size=100 ... (use "-full stsc" to show all)` + "\n" +
@@ -219,7 +219,7 @@ var sampleMP4OutputOffset = "" +
 	`            [url ] Offset=7569 Size=12 Version=0 Flags=0x000001` + "\n" +
 	`        [stbl] Offset=7581 Size=564` + "\n" +
 	`          [stsd] Offset=7589 Size=106 Version=0 Flags=0x000000 EntryCount=1` + "\n" +
-	`            [mp4a] Offset=7605 Size=90 DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=2890137600` + "\n" +
+	`            [mp4a] Offset=7605 Size=90 DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=44100` + "\n" +
 	`              [esds] Offset=7641 Size=54 ... (use "-full esds" to show all)` + "\n" +
 	`          [stts] Offset=7695 Size=48 ... (use "-full stts" to show all)` + "\n" +
 	`          [stsc] Offset=7743 Size=100 ... (use "-full stsc" to show all)` + "\n" +
@@ -278,7 +278,7 @@ var sampleMP4OutputHex = "" +
 	`            [url ] Size=0xc Version=0 Flags=0x000001` + "\n" +
 	`        [stbl] Size=0x234` + "\n" +
 	`          [stsd] Size=0x6a Version=0 Flags=0x000000 EntryCount=1` + "\n" +
-	`            [mp4a] Size=0x5a DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=2890137600` + "\n" +
+	`            [mp4a] Size=0x5a DataReferenceIndex=1 EntryVersion=0 ChannelCount=2 SampleSize=16 PreDefined=0 SampleRate=44100` + "\n" +
 	`              [esds] Size=0x36 ... (use "-full esds" to show all)` + "\n" +
 	`          [stts] Size=0x30 ... (use "-full stts" to show all)` + "\n" +
 	`          [stsc] Size=0x64 ... (use "-full stsc" to show all)` + "\n" +


### PR DESCRIPTION
Issue: #137 

Fix to display `AudioSampleEntry.SampleRate` with human-readable format.