### PR TITLE
Prevent RAM exhaustion by limiting maximum value of some fields

### DIFF
--- a/box_types_iso14496_12.go
+++ b/box_types_iso14496_12.go
@@ -638,6 +638,10 @@ func (hdlr *Hdlr) OnReadName(r bitio.ReadSeeker, leftBits uint64, ctx Context) (
 		return 0, true, nil
 	}
 
+	if size > maxFieldLength {
+		return 0, false, fmt.Errorf("out of memory: requestedSize=%d", size)
+	}
+
 	buf := make([]byte, size)
 	if _, err := io.ReadFull(r, buf); err != nil {
 		return 0, false, err

--- a/marshaller.go
+++ b/marshaller.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	anyVersion = math.MaxUint8
+	maxFieldLength = 100 * 1024
 )
 
 var ErrUnsupportedBoxVersion = errors.New("unsupported box version")
@@ -417,7 +418,7 @@ func (u *unmarshaller) unmarshalSlice(v reflect.Value, fi *fieldInstance) error 
 		}
 	}
 
-	if length > math.MaxInt32 {
+	if length > maxFieldLength {
 		return fmt.Errorf("out of memory: requestedSize=%d", length)
 	}
 

--- a/read.go
+++ b/read.go
@@ -50,7 +50,7 @@ func readBoxStructureFromInternal(r io.ReadSeeker, bi *BoxInfo, path BoxPath, ha
 		return nil, err
 	}
 
-	// check comatible-brands
+	// check compatible-brands
 	if len(path) == 0 && bi.Type == BoxTypeFtyp() {
 		var ftyp Ftyp
 		if _, err := Unmarshal(r, bi.Size-bi.HeaderSize, &ftyp, bi.Context); err != nil {


### PR DESCRIPTION
@sunfish-shogi

Currently it's possible to exhaust available memory by inserting very large numbers into various size fields. This PR adds additional checks on a couple of size fields:

* hdlr's name size, which is currently unchecked and is passed directly to make([]byte)

* slice size, which is currently limited to 4.2GB, and is passed directly to make([]byte)

Both are now limited to 100KB. I'm not aware of any MP4 field whose content can exceed 100KB (excluding the content of mdat, which is not unmarshaled).
