### PR TITLE
Prevent RAM exhaustion

### DIFF
--- a/box_types_iso14496_12.go
+++ b/box_types_iso14496_12.go
@@ -637,6 +637,9 @@ func (hdlr *Hdlr) OnReadName(r bitio.ReadSeeker, leftBits uint64, ctx Context) (
 		hdlr.Name = ""
 		return 0, true, nil
 	}
+	if size > 1024 {
+		return 0, false, errors.New("too large hdlr box")
+	}
 
 	buf := make([]byte, size)
 	if _, err := io.ReadFull(r, buf); err != nil {

--- a/box_types_iso14496_12_test.go
+++ b/box_types_iso14496_12_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2781,6 +2782,43 @@ func TestFtypCompatibleBrands(t *testing.T) {
 	require.False(t, ftyp.HasCompatibleBrand(BrandISO5()))
 	require.True(t, ftyp.HasCompatibleBrand(BrandISO6()))
 	require.False(t, ftyp.HasCompatibleBrand(BrandISO7()))
+}
+
+func TestHdlrLargeSize(t *testing.T) {
+	t.Run("no-error", func(t *testing.T) {
+		bin := append([]byte{
+			0,                // version
+			0x00, 0x00, 0x00, // flags
+			0x00, 0x00, 0x00, 0x00,
+			'v', 'i', 'd', 'e', // handler type
+			0x00, 0x00, 0x00, 0x00, // reserved
+			0x00, 0x00, 0x00, 0x00, // reserved
+			0x00, 0x00, 0x00, 0x00, // reserved
+		}, []byte(strings.Repeat("x", 1024))...)
+		dst := Hdlr{}
+		r := bytes.NewReader(bin)
+		n, err := Unmarshal(r, uint64(len(bin)), &dst, Context{})
+		require.NoError(t, err)
+		assert.Equal(t, uint64(len(bin)), n)
+		assert.Equal(t, strings.Repeat("x", 1024), dst.Name)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		bin := append([]byte{
+			0,                // version
+			0x00, 0x00, 0x00, // flags
+			0x00, 0x00, 0x00, 0x00,
+			'v', 'i', 'd', 'e', // handler type
+			0x00, 0x00, 0x00, 0x00, // reserved
+			0x00, 0x00, 0x00, 0x00, // reserved
+			0x00, 0x00, 0x00, 0x00, // reserved
+		}, []byte(strings.Repeat("x", 1025))...)
+		dst := Hdlr{}
+		r := bytes.NewReader(bin)
+		_, err := Unmarshal(r, uint64(len(bin)), &dst, Context{})
+		require.Error(t, err)
+		assert.Equal(t, "too large hdlr box", err.Error())
+	})
 }
 
 func TestHdlrUnmarshalHandlerName(t *testing.T) {


### PR DESCRIPTION
This change prevents RAM exhaustion.

- Limit first slice capacity in common marshaller.
  - Exclude mdat-box.
  - Will not limit for reallocation. (If requested length is larger than real remaining file size, return EOF error.)
- Return an error if name length of hdlr-box is larger than 1024.

#149 
#146