### PR TITLE
Prevent infinite loop when calling ReadBoxStructure

### DIFF
--- a/box_info.go
+++ b/box_info.go
@@ -3,6 +3,7 @@ package mp4
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math"
 )
@@ -128,7 +129,6 @@ func ReadBoxInfo(r io.ReadSeeker) (*BoxInfo, error) {
 		if _, err := bi.SeekToPayload(r); err != nil {
 			return nil, err
 		}
-
 	} else if bi.Size == 1 {
 		// read more 8 bytes
 		buf.Reset()
@@ -137,6 +137,10 @@ func ReadBoxInfo(r io.ReadSeeker) (*BoxInfo, error) {
 		}
 		bi.HeaderSize += LargeHeaderSize - SmallHeaderSize
 		bi.Size = binary.BigEndian.Uint64(buf.Bytes())
+	}
+
+	if bi.Size == 0 {
+		return nil, fmt.Errorf("invalid size")
 	}
 
 	return bi, nil

--- a/read_test.go
+++ b/read_test.go
@@ -228,3 +228,13 @@ func TestReadBoxStructureQT(t *testing.T) {
 // 47	          [stsc] Size=28 Version=0 Flags=0x000000 EntryCount=1 Entries=[{FirstChunk=1 SamplesPerChunk=1 SampleDescriptionIndex=1}]
 // 48	          [stsz] Size=111852 ... (use "-full stsz" to show all)
 // 49	          [stco] Size=111848 ... (use "-full stco" to show all)
+
+// this used to cause an infinite loop.
+func TestReadBoxStructureZeroSize(t *testing.T) {
+	b := []byte("\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01")
+
+	_, err := ReadBoxStructure(bytes.NewReader(b), func(h *ReadHandle) (interface{}, error) {
+		return nil, nil
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
@sunfish-shogi

When ReadBoxStructure is called against a box with a size of zero, an infinite loop is generated due to the fact that the loop contained in readBoxStructure() never ends. This patch fixes the issue and provides a test case.
