### PR TITLE
add ISO 23001-5 boxes

### DIFF
--- a/box_types_iso23001_5.go
+++ b/box_types_iso23001_5.go
@@ -1,0 +1,35 @@
+package mp4
+
+/*************************** ipcm ****************************/
+
+func BoxTypeIpcm() BoxType { return StrToBoxType("ipcm") }
+
+func init() {
+	AddAnyTypeBoxDef(&AudioSampleEntry{}, BoxTypeIpcm())
+}
+
+/*************************** fpcm ****************************/
+
+func BoxTypeFpcm() BoxType { return StrToBoxType("fpcm") }
+
+func init() {
+	AddAnyTypeBoxDef(&AudioSampleEntry{}, BoxTypeFpcm())
+}
+
+/*************************** pcmC ****************************/
+
+func BoxTypePcmC() BoxType { return StrToBoxType("pcmC") }
+
+func init() {
+	AddBoxDef(&PcmC{}, 0, 1)
+}
+
+type PcmC struct {
+	FullBox       `mp4:"0,extend"`
+	FormatFlags   uint8 `mp4:"1,size=8"`
+	PCMSampleSize uint8 `mp4:"1,size=8"`
+}
+
+func (PcmC) GetType() BoxType {
+	return BoxTypePcmC()
+}

--- a/box_types_iso23001_5_test.go
+++ b/box_types_iso23001_5_test.go
@@ -1,0 +1,66 @@
+package mp4
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoxTypesISO23001_5(t *testing.T) {
+	testCases := []struct {
+		name string
+		src  IImmutableBox
+		dst  IBox
+		bin  []byte
+		str  string
+		ctx  Context
+	}{
+		{
+			name: "pcmC",
+			src: &PcmC{
+				FormatFlags:   1,
+				PCMSampleSize: 32,
+			},
+			dst: &PcmC{},
+			bin: []byte{0x0, 0x0, 0x0, 0x0, 0x1, 0x20},
+			str: `Version=0 Flags=0x000000 FormatFlags=0x1 PCMSampleSize=0x20`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Marshal
+			buf := bytes.NewBuffer(nil)
+			n, err := Marshal(buf, tc.src, tc.ctx)
+			require.NoError(t, err)
+			assert.Equal(t, uint64(len(tc.bin)), n)
+			assert.Equal(t, tc.bin, buf.Bytes())
+
+			// Unmarshal
+			r := bytes.NewReader(tc.bin)
+			n, err = Unmarshal(r, uint64(len(tc.bin)), tc.dst, tc.ctx)
+			require.NoError(t, err)
+			assert.Equal(t, uint64(buf.Len()), n)
+			assert.Equal(t, tc.src, tc.dst)
+			s, err := r.Seek(0, io.SeekCurrent)
+			require.NoError(t, err)
+			assert.Equal(t, int64(buf.Len()), s)
+
+			// UnmarshalAny
+			dst, n, err := UnmarshalAny(bytes.NewReader(tc.bin), tc.src.GetType(), uint64(len(tc.bin)), tc.ctx)
+			require.NoError(t, err)
+			assert.Equal(t, uint64(buf.Len()), n)
+			assert.Equal(t, tc.src, dst)
+			s, err = r.Seek(0, io.SeekCurrent)
+			require.NoError(t, err)
+			assert.Equal(t, int64(buf.Len()), s)
+
+			// Stringify
+			str, err := Stringify(tc.src, tc.ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tc.str, str)
+		})
+	}
+}


### PR DESCRIPTION
@sunfish-shogi

These boxes allows to marshal and unmarshal uncompressed audio tracks.

Tested with VLC and FFmpeg.