### PR TITLE
Fix integer divide by zero in Samples.GetMaxBitrate

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -645,9 +645,11 @@ func (samples Samples) GetMaxBitrate(timescale uint32, timeDelta uint64) uint64 
 				break
 			}
 		}
-		bitrate := 8 * size * uint64(timescale) / duration
-		if bitrate > maxBitrate {
-			maxBitrate = bitrate
+		if duration != 0 {
+			bitrate := 8 * size * uint64(timescale) / duration
+			if bitrate > maxBitrate {
+				maxBitrate = bitrate
+			}
 		}
 		for {
 			size -= uint64(samples[begin].Size)

--- a/probe_test.go
+++ b/probe_test.go
@@ -352,6 +352,13 @@ func TestSamplesGetMaxBitrate(t *testing.T) {
 			{TimeDelta: 10, Size: 100},
 			{TimeDelta: 10, Size: 200},
 		}.GetMaxBitrate(100, 20))
+
+	// samples whose time deltas are all zero must not divide by zero
+	assert.Equal(t, uint64(0),
+		Samples{
+			{TimeDelta: 0, Size: 100},
+			{TimeDelta: 0, Size: 200},
+		}.GetMaxBitrate(100, 20))
 }
 
 func TestSegmentsGetBitrate(t *testing.T) {


### PR DESCRIPTION
### What

`Samples.GetMaxBitrate` divides by the accumulated window `duration` without checking it for zero, so it can panic with `runtime error: integer divide by zero`.

The inner loop accumulates `duration` until it reaches `timeDelta` or runs out of samples. If the remaining samples all have a zero `TimeDelta`, the loop exits because it hit the end of the slice with `duration` still `0`, and the following line panics:

```go
bitrate := 8 * size * uint64(timescale) / duration
```

This is reachable from parsed input: a track whose `stts` entries all carry `SampleDelta == 0` produces samples with `TimeDelta == 0`, so calling `GetMaxBitrate` on the result of `Probe` panics.

### Fix

Guard the division against a zero duration, matching what `GetBitrate` already does for its total duration. With no positive duration there is no meaningful bitrate to contribute, so the window is skipped and the function returns `0` for such input instead of crashing.

### Test

Added a case to `TestSamplesGetMaxBitrate` with all-zero time deltas. It panics before the change and passes after.
