### PR TITLE
Fix numTemporalLayers and temporalIdNested bit widths in hvcC

### DIFF
--- a/box_types_iso14496_12.go
+++ b/box_types_iso14496_12.go
@@ -726,8 +726,8 @@ type HvcC struct {
 	BitDepthChromaMinus8        uint8           `mp4:"16,size=3"`
 	AvgFrameRate                uint16          `mp4:"17,size=16"`
 	ConstantFrameRate           uint8           `mp4:"18,size=2"`
-	NumTemporalLayers           uint8           `mp4:"19,size=2"`
-	TemporalIdNested            uint8           `mp4:"20,size=2"`
+	NumTemporalLayers           uint8           `mp4:"19,size=3"`
+	TemporalIdNested            uint8           `mp4:"20,size=1"`
 	LengthSizeMinusOne          uint8           `mp4:"21,size=2"`
 	NumOfNaluArrays             uint8           `mp4:"22,size=8"`
 	NaluArrays                  []HEVCNaluArray `mp4:"23,len=dynamic"`

--- a/box_types_iso14496_12_test.go
+++ b/box_types_iso14496_12_test.go
@@ -476,7 +476,8 @@ func TestBoxTypesISO14496_12(t *testing.T) {
 				ChromaFormatIdc:            1,
 				Reserved4:                  31,
 				Reserved5:                  31,
-				TemporalIdNested:           3,
+				NumTemporalLayers:          1,
+				TemporalIdNested:           1,
 				LengthSizeMinusOne:         3,
 				NumOfNaluArrays:            4,
 				NaluArrays: []HEVCNaluArray{
@@ -554,7 +555,7 @@ func TestBoxTypesISO14496_12(t *testing.T) {
 				`false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, ` +
 				`false, false, false, false, false, false] GeneralConstraintIndicator=[0x90, 0x0, 0x0, 0x0, 0x0, 0x0] GeneralLevelIdc=0x78 ` +
 				`MinSpatialSegmentationIdc=0 ParallelismType=0x0 ChromaFormatIdc=0x1 BitDepthLumaMinus8=0x0 BitDepthChromaMinus8=0x0 ` +
-				`AvgFrameRate=0 ConstantFrameRate=0x0 NumTemporalLayers=0x0 TemporalIdNested=0x3 LengthSizeMinusOne=0x3 NumOfNaluArrays=0x4 ` +
+				`AvgFrameRate=0 ConstantFrameRate=0x0 NumTemporalLayers=0x1 TemporalIdNested=0x1 LengthSizeMinusOne=0x3 NumOfNaluArrays=0x4 ` +
 				`NaluArrays=[{Completeness=false Reserved=false NaluType=0x20 NumNalus=1 Nalus=[{Length=24 NALUnit=[0x40, 0x1, 0xc, 0x1, ` +
 				`0xff, 0xff, 0x1, 0x60, 0x0, 0x0, 0x3, 0x0, 0x90, 0x0, 0x0, 0x3, 0x0, 0x0, 0x3, 0x0, 0x78, 0x99, 0x98, 0x9]}]}, ` +
 				`{Completeness=false Reserved=false NaluType=0x21 NumNalus=1 Nalus=[{Length=42 NALUnit=[0x6, 0x1, 0x1, 0x1, 0x60, 0x0, ` +
@@ -563,6 +564,52 @@ func TestBoxTypesISO14496_12(t *testing.T) {
 				`NaluType=0x22 NumNalus=1 Nalus=[{Length=7 NALUnit=[0x44, 0x1, 0xc1, 0x72, 0xb4, 0x62, 0x40]}]}, ` +
 				`{Completeness=false Reserved=false NaluType=0x27 NumNalus=1 Nalus=[{Length=11 NALUnit=[0x4e, 0x1, 0x5, 0xff, 0xff, 0xff, ` +
 				`0xa6, 0x2c, 0xa2, 0xde, 0x9]}]}]`,
+		},
+		{
+			// numTemporalLayers is 3 bits wide and temporalIdNested is 1 bit wide,
+			// so the byte after avgFrameRate splits as 2+3+1+2 bits.
+			name: "hvcC: numTemporalLayers",
+			src: &HvcC{
+				ConfigurationVersion:       1,
+				GeneralProfileIdc:          1,
+				GeneralConstraintIndicator: [6]uint8{144, 0, 0, 0, 0, 0},
+				GeneralLevelIdc:            120,
+				Reserved1:                  0xf,
+				Reserved2:                  0x3f,
+				Reserved3:                  0x3f,
+				ChromaFormatIdc:            1,
+				Reserved4:                  31,
+				Reserved5:                  31,
+				ConstantFrameRate:          0,
+				NumTemporalLayers:          4,
+				TemporalIdNested:           1,
+				LengthSizeMinusOne:         3,
+				NumOfNaluArrays:            0,
+				NaluArrays:                 []HEVCNaluArray{},
+			},
+			dst: &HvcC{},
+			bin: []byte{
+				0x01,                   // configurationVersion
+				0x01,                   // generalProfileSpace, generalTierFlag, generalProfileIdc
+				0x00, 0x00, 0x00, 0x00, // generalProfileCompatibility
+				0x90, 0x00, 0x00, 0x00, 0x00, 0x00, // generalConstraintIndicator
+				0x78,       // generalLevelIdc
+				0xf0, 0x00, // reserved, minSpatialSegmentationIdc
+				0xfc,       // reserved, parallelismType
+				0xfd,       // reserved, chromaFormatIdc
+				0xf8,       // reserved, bitDepthLumaMinus8
+				0xf8,       // reserved, bitDepthChromaMinus8
+				0x00, 0x00, // avgFrameRate
+				0x27, // constantFrameRate=0, numTemporalLayers=4, temporalIdNested=1, lengthSizeMinusOne=3
+				0x00, // numOfNaluArrays
+			},
+			str: `ConfigurationVersion=0x1 GeneralProfileSpace=0x0 GeneralTierFlag=false GeneralProfileIdc=0x1 ` +
+				`GeneralProfileCompatibility=[false, false, false, false, false, false, false, false, false, false, false, ` +
+				`false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, ` +
+				`false, false, false, false, false, false] GeneralConstraintIndicator=[0x90, 0x0, 0x0, 0x0, 0x0, 0x0] GeneralLevelIdc=0x78 ` +
+				`MinSpatialSegmentationIdc=0 ParallelismType=0x0 ChromaFormatIdc=0x1 BitDepthLumaMinus8=0x0 BitDepthChromaMinus8=0x0 ` +
+				`AvgFrameRate=0 ConstantFrameRate=0x0 NumTemporalLayers=0x4 TemporalIdNested=0x1 LengthSizeMinusOne=0x3 NumOfNaluArrays=0x0 ` +
+				`NaluArrays=[]`,
 		},
 		{
 			name: "mdat",


### PR DESCRIPTION
@sunfish-shogi

`HvcC` splits the byte after `avgFrameRate` into the wrong fields. ISO/IEC 14496-15 defines that byte of `HEVCDecoderConfigurationRecord` as `constantFrameRate(2)`, `numTemporalLayers(3)`, `temporalIdNested(1)`, `lengthSizeMinusOne(2)`, but `box_types_iso14496_12.go:729-730` declares `NumTemporalLayers` and `TemporalIdNested` as 2 bits each. The widths still add up to 8, so the box parses and `LengthSizeMinusOne` comes out right, which is probably why nobody hit this.

Both middle fields are wrong in both directions. Unmarshalling the byte `0x0f`, which is what the existing hvcC test case already carries, gives `NumTemporalLayers=0` and `TemporalIdNested=3` where the record says 1 and 1, and `temporalIdNested` is a one-bit flag that cannot hold 3. Marshalling truncates: a record with `numTemporalLayers=4` writes `0x07` instead of `0x27`, silently dropping the high bit and producing an hvcC that other parsers read back as `numTemporalLayers=0`.

The fix sets `NumTemporalLayers` to `size=3` and `TemporalIdNested` to `size=1`. Nothing else in the repository reads either field, and `LengthSizeMinusOne`, which `probe.go` does use through `avcC`, is untouched.

For tests, the existing `hvcC` case keeps its exact byte sequence and now expects `NumTemporalLayers=1` and `TemporalIdNested=1`, the values that byte actually encodes. I added a second case, `hvcC: numTemporalLayers`, with `numTemporalLayers=4`, a value the old 2-bit field cannot represent, so the split stays pinned.

Verified on go1.26.4 darwin/arm64. With only the two struct tags reverted to master, both cases fail: the existing one marshals `0x17` instead of `0x0f` and unmarshals `NumTemporalLayers` as 0, and the new one marshals `0x07` instead of `0x27` and unmarshals `NumTemporalLayers` as 2. With the fix, `go test -run 'TestBoxTypesISO14496_12/hvcC' -v .` passes both. `gofmt -l .` is empty, `go vet ./...` is clean, `go build ./...` succeeds, and the whole suite passes: `go test ./...` reports ok for `github.com/abema/go-mp4`, `internal/bitio`, `internal/util` and the four `cmd/mp4tool` packages that have tests.
